### PR TITLE
update example to hal 0.22.0

### DIFF
--- a/esp32c3/.cargo/config.toml
+++ b/esp32c3/.cargo/config.toml
@@ -1,11 +1,18 @@
-[target.riscv32imac-unknown-none-elf]
-runner = "espflash --release --monitor"
+[target.riscv32imc-unknown-none-elf]
+runner = "espflash flash --monitor"
+
+[env]
+ESP_LOG="INFO"
 
 [build]
 rustflags = [
+    # Required to obtain backtraces (e.g. when using the "esp-backtrace" crate.)
+    # NOTE: May negatively impact performance of produced code
+    "-C", "force-frame-pointers",
     "-C", "link-arg=-Tlinkall.x",
 ]
-target = "riscv32imac-unknown-none-elf"
+
+target = "riscv32imc-unknown-none-elf"
 
 [unstable]
 build-std = ["core"]

--- a/esp32c3/Cargo.toml
+++ b/esp32c3/Cargo.toml
@@ -6,8 +6,18 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-esp-backtrace = { version = "0.10.0", features = ["esp32c3", "exception-handler", "panic-handler", "print-jtag-serial"] }
-esp32c3-hal   = "0.15.0"
-icm42670      = "0.1.1"
-riscv-rt      = { version = "0.12.2", optional = true }
-critical-section = "1.1.2"
+esp-backtrace = { version = "0.14.2", features = [
+    "esp32c3",
+    "exception-handler",
+    "panic-handler",
+    "println",
+]}
+
+esp-hal = { version = "0.22.0", features = [
+    "esp32c3",
+] }
+esp-println = { version = "0.12.0", features = ["esp32c3", "log"] }
+log = { version = "0.4.21" }
+critical-section = "1.2.0"
+icm42670      = "0.2.0"
+embedded-hal = "1.0.0"

--- a/esp32c3/rust-toolchain.toml
+++ b/esp32c3/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly"


### PR DESCRIPTION
Here's the updated version of the example to esp-hal 0.22.0.
The application was tested by the command:
```
cargo run --release --example normalized_data
```
The application works on ESP32-C3-RUST-DevKit.